### PR TITLE
Change cursor to default for read only version

### DIFF
--- a/src/jquery.rateyo.css
+++ b/src/jquery.rateyo.css
@@ -29,3 +29,6 @@
   left: 0;
   overflow: hidden;
 }
+.rateyo-readonly-widg {
+  cursor: default;
+}


### PR DESCRIPTION
When the user attempts to click on a read-only version of the stars, the cursor:pointer still displays even when the stars are not clickable. This pull request fixes that.