### PR TITLE
Allow to pass SVG star as an option

### DIFF
--- a/src/jquery.rateyo.js
+++ b/src/jquery.rateyo.js
@@ -40,7 +40,8 @@
     multiColor: null,
     onInit    : null,
     onChange  : null,
-    onSet     : null
+    onSet     : null,
+    starSvg   : null
   };
 
   //Default colors for multi-color rating
@@ -425,8 +426,8 @@
 
       for (var i=0; i<options.numStars; i++) {
 
-        $normalGroup.append($(BASICSTAR));
-        $ratedGroup.append($(BASICSTAR));
+        $normalGroup.append($(options.starSvg || BASICSTAR));
+        $ratedGroup.append($(options.starSvg || BASICSTAR));
       }
 
       setStarWidth(options.starWidth);


### PR DESCRIPTION
It's convenient to be able to pass SVG star icon as an option (without the need to change rateYo code).