### PR TITLE
Update package.json's main option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rateyo",
   "version": "2.3.3",
   "description": "A simple and flexible star rating plugin",
-  "main": "js/jquery.rateyo.js",
+  "main": "src/jquery.rateyo.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/prrashi/rateYo.git"


### PR DESCRIPTION
Not sure if this was the right thing to do. But the file that `main` previously pointed to (`js/jquery.rateyo.js`) didn't exist in the project and this got it working in my setup.