### PR TITLE
Add hover option

### DIFF
--- a/src/jquery.rateyo.js
+++ b/src/jquery.rateyo.js
@@ -34,6 +34,7 @@
     rating    : 0,
     fullStar  : false,
     halfStar  : false,
+    hover     : true,
     readOnly  : false,
     spacing   : "0px",
     rtl       : false,
@@ -860,7 +861,9 @@
     };
 
     function onMouseEnter (e) {
-
+      if (!options.hover) {
+        return;
+      }
       /*
        * If the Mouse Pointer is inside the container, calculate and show the rating
        * in UI
@@ -878,7 +881,7 @@
     }
 
     function onMouseLeave () {
-      if (isMobileBrowser()) {
+      if (isMobileBrowser() || !options.hover) {
         return;
       }
 


### PR DESCRIPTION
Many star forms online do not change on hover but only on click (Google reviews for instance).  I prefer this behavior and find the hover effect slightly confusing.  This adds boolean option "hover" that defaults to "true".  Leaving it alone will keep the default behavior.  Setting it to false will disable hover affect.